### PR TITLE
Adding endpoint into Switch Entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,14 @@ It is also possible to combine devices - tasmota device can be used to switch a 
         {
             "addr": "0xAC3C",
             "type": "switch",
-            "name": "Switch", 
+            "name": "Switch-1", 
             "endpoint": 1
+        }, 
+        {
+            "addr": "0xAC3C",
+            "type": "switch",
+            "name": "Switch-2", 
+            "endpoint": 2
         }, 
         {
             "addr": "0xAD0B",
@@ -90,6 +96,7 @@ It is also possible to combine devices - tasmota device can be used to switch a 
 * `type` - Device type (`light0`, `light1`, `light2`, `light3`, `switch`) see descriptions in `config.schema.json`. Alternatively use generic `light` and add features as needed: `_B` for brigthness, `_CT` for color temperature, `_HS` for hue and saturation and `_XY` for XY color support.
 Generic sennsors are suported by defining the type as follows: `sensor_<Cluster>_<ReadCommand>_<Service>_<Characteristic>_<ValuePath>`
 * `name` - Accessory name to be used in the Home applicaiton. Should be unique. Will update ZbBridge Friendly Name
+* `endpoint` - (optional) Use more than one endpoint for Switch accessories (for example Tuya 2ch Switch)
 * `powerTopic` - (optional) Use another tasmota device to controll the power
 * `powerType` - (optional) Which tasmota switch to use, default: `POWER`
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ It is also possible to combine devices - tasmota device can be used to switch a 
         {
             "addr": "0xAC3C",
             "type": "switch",
-            "name": "Switch"
+            "name": "Switch", 
+            "endpoint": 1
+        }, 
+        {
+            "addr": "0xAD0B",
+            "type": "switch",
+            "name": "Kitchen Ligths"
         }
     ],
     "tasmotaDevices": [

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ It is also possible to combine devices - tasmota device can be used to switch a 
 * `addr` - Device short address
 * `type` - Device type (`light0`, `light1`, `light2`, `light3`, `switch`) see descriptions in `config.schema.json`. Alternatively use generic `light` and add features as needed: `_B` for brigthness, `_CT` for color temperature, `_HS` for hue and saturation and `_XY` for XY color support.
 Generic sennsors are suported by defining the type as follows: `sensor_<Cluster>_<ReadCommand>_<Service>_<Characteristic>_<ValuePath>`
-* `name` - Accessory name to be used in the Home applicaiton. Should be unique. Will update ZbBridge Friendly Name
+* `name` - Accessory name to be used in the Home applicaiton. Should be unique. Will update ZbBridge Friendly Name if endpoint is not used. 
 * `endpoint` - (optional) Use more than one endpoint for Switch accessories (for example Tuya 2ch Switch)
 * `powerTopic` - (optional) Use another tasmota device to controll the power
 * `powerType` - (optional) Which tasmota switch to use, default: `POWER`

--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,11 @@
               "placeholder": "HomeKit name",
               "required": true
             },
+            "endpoint": {
+              "title": "Endpoint number",
+              "type": "number",
+              "placeholder": "Endpoint number"
+            },
             "powerTopic": {
               "title": "Power Topic",
               "placeholder": "Topic",

--- a/config.schema.json
+++ b/config.schema.json
@@ -243,6 +243,15 @@
                 "notitle": true,
                 "key": "zbBridgeDevices[].name"
               }]
+            }, 
+            {
+              "type": "flex",
+              "flex-flow": "column",
+              "items": [{
+                "nodescription": true,
+                "notitle": true,
+                "key": "zbBridgeDevices[].endpoint"
+              }]
             }
           ]
         }, {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Homebridge Tasmota ZbBridge Marek",
+  "displayName": "Homebridge Tasmota ZbBridge",
   "name": "homebridge-tasmota-zbbridge",
   "version": "0.11.2",
   "description": "Control Zigbee Devices Using Tasmota ZbBridge",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "displayName": "Homebridge Tasmota ZbBridge",
+  "displayName": "Homebridge Tasmota ZbBridge Marek",
   "name": "homebridge-tasmota-zbbridge",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Control Zigbee Devices Using Tasmota ZbBridge",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mdaskalov/homebridge-tasmota-zbbridge.git"
+    "url": "git://github.com/maerneker/homebridge-tasmota-zbbridge.git"
   },
   "bugs": {
-    "url": "https://github.com/mdaskalov/homebridge-tasmota-zbbridge/issues"
+    "url": "https://github.com/maerneker/homebridge-tasmota-zbbridge/issues"
   },
   "engines": {
     "node": ">=10.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "displayName": "Homebridge Tasmota ZbBridge Marek",
-  "name": "homebridge-tasmota-zbbridge",
+  "name": "homebridge-tasmota-zbbridge-me",
   "version": "0.11.0",
   "description": "Control Zigbee Devices Using Tasmota ZbBridge",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Tasmota ZbBridge Marek",
-  "name": "homebridge-tasmota-zbbridge-me",
-  "version": "0.11.1",
+  "name": "homebridge-tasmota-zbbridge",
+  "version": "0.11.2",
   "description": "Control Zigbee Devices Using Tasmota ZbBridge",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Tasmota ZbBridge Marek",
   "name": "homebridge-tasmota-zbbridge-me",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Control Zigbee Devices Using Tasmota ZbBridge",
   "license": "Apache-2.0",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -35,7 +35,11 @@ export class TasmotaZbBridgePlatform implements DynamicPlatformPlugin {
   }
 
   zbBridgeDeviceUUID(device: ZbBridgeDevice) {
-    return this.api.hap.uuid.generate(device.addr);
+    if (device.endpoint !== -1) {
+      return this.api.hap.uuid.generate(device.addr + '-' + device.endpoint);
+    } else {
+      return this.api.hap.uuid.generate(device.addr);
+    }
   }
 
   tasmotaDeviceUUID(device: TasmotaDevice) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,4 +6,4 @@ export const PLATFORM_NAME = 'TasmotaZbBridge';
 /**
  * This must match the name of your plugin as defined the package.json
  */
-export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge-me';
+export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,4 +6,4 @@ export const PLATFORM_NAME = 'TasmotaZbBridge';
 /**
  * This must match the name of your plugin as defined the package.json
  */
-export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge';
+export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge-marek';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,4 +6,4 @@ export const PLATFORM_NAME = 'TasmotaZbBridge';
 /**
  * This must match the name of your plugin as defined the package.json
  */
-export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge';
+export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge-me';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,4 +6,4 @@ export const PLATFORM_NAME = 'TasmotaZbBridge';
 /**
  * This must match the name of your plugin as defined the package.json
  */
-export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge-marek';
+export const PLUGIN_NAME = 'homebridge-tasmota-zbbridge';

--- a/src/zbBridgeAccessory.ts
+++ b/src/zbBridgeAccessory.ts
@@ -9,7 +9,8 @@ import { TasmotaZbBridgePlatform } from './platform';
 export type ZbBridgeDevice = {
   addr: string,
   type: string,
-  name: string
+  name: string, 
+  endpoint: number
 }
 
 type StatusUpdateHandler = {

--- a/src/zbBridgeAccessory.ts
+++ b/src/zbBridgeAccessory.ts
@@ -23,6 +23,7 @@ export abstract class ZbBridgeAccessory {
   protected service: Service;
   protected powerTopic?: string;
   protected addr: string;
+  protected endpoint: number;
   protected type: string;
   protected reachable: boolean | undefined;
   protected ignoreUpdatesUntil = 0;
@@ -32,6 +33,11 @@ export abstract class ZbBridgeAccessory {
     this.addr = this.accessory.context.device.addr;
     this.type = this.accessory.context.device.type;
     this.reachable = undefined;
+    this.endpoint = -1; 
+
+    if (this.accessory.context.device.endpoint !== undefined) {
+      this.endpoint = this.accessory.context.device.endpoint;
+    }
 
     const serviceName = this.getServiceName();
     const service = this.platform.Service[serviceName];

--- a/src/zbBridgeAccessory.ts
+++ b/src/zbBridgeAccessory.ts
@@ -76,10 +76,10 @@ export abstract class ZbBridgeAccessory {
       }
     });
 
-    this.platform.mqttClient.publish(
-      'cmnd/' + this.platform.mqttClient.topic + '/zbname',
-      this.addr + ',' + accessory.context.device.name,
-    );
+    // this.platform.mqttClient.publish(
+    //   'cmnd/' + this.platform.mqttClient.topic + '/zbname',
+    //   this.addr + ',' + accessory.context.device.name,
+    // );
 
     this.registerHandlers();
 

--- a/src/zbBridgeAccessory.ts
+++ b/src/zbBridgeAccessory.ts
@@ -33,13 +33,9 @@ export abstract class ZbBridgeAccessory {
   constructor(protected readonly platform: TasmotaZbBridgePlatform, protected readonly accessory: PlatformAccessory) {
     this.addr = this.accessory.context.device.addr;
     this.type = this.accessory.context.device.type;
+    this.endpoint = this.accessory.context.device.endpoint; 
     this.reachable = undefined;
-    this.endpoint = -1; 
-
-    if (this.accessory.context.device.endpoint !== undefined) {
-      this.endpoint = this.accessory.context.device.endpoint;
-    }
-
+    
     const serviceName = this.getServiceName();
     const service = this.platform.Service[serviceName];
     if (service === undefined) {
@@ -76,10 +72,12 @@ export abstract class ZbBridgeAccessory {
       }
     });
 
-    // this.platform.mqttClient.publish(
-    //   'cmnd/' + this.platform.mqttClient.topic + '/zbname',
-    //   this.addr + ',' + accessory.context.device.name,
-    // );
+    if (this.endpoint === undefined) {
+      this.platform.mqttClient.publish(
+        'cmnd/' + this.platform.mqttClient.topic + '/zbname',
+        this.addr + ',' + accessory.context.device.name,
+      );
+    }
 
     this.registerHandlers();
 

--- a/src/zbBridgeSwitch.ts
+++ b/src/zbBridgeSwitch.ts
@@ -27,7 +27,6 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
       } else {
         this.mqttSend({ device: this.addr, cluster: 6, read: 0 });
       }
-      
     }
   }
 

--- a/src/zbBridgeSwitch.ts
+++ b/src/zbBridgeSwitch.ts
@@ -22,7 +22,12 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
     if (this.powerTopic !== undefined) {
       this.platform.mqttClient.publish('cmnd/' + this.powerTopic, '');
     } else {
-      this.mqttSend({ device: this.addr, cluster: 6, read: 0 });
+      if (this.endpoint !== -1) {
+        this.mqttSend({ device: this.addr, endpoint: this.endpoint, cluster: 6, read: 0 });
+      } else {
+        this.mqttSend({ device: this.addr, cluster: 6, read: 0 });
+      }
+      
     }
   }
 
@@ -57,7 +62,11 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
         await this.externalPower(power ? 'ON' : 'OFF');
       } else {
         this.power = power;
-        await this.zbSend({ device: this.addr, send: { Power: (this.power ? 'On' : 'Off') } });
+        if (this.endpoint !== -1) {
+          await this.zbSend({ device: this.addr, endpoint: this.endpoint, send: { Power: (this.power ? 'On' : 'Off') } });
+        } else {
+          await this.zbSend({ device: this.addr, send: { Power: (this.power ? 'On' : 'Off') } });
+        }
       }
     }
   }
@@ -69,7 +78,11 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
     if (this.powerTopic !== undefined) {
       await this.externalPower();
     } else {
-      await this.zbSend({ device: this.addr, cluster: 6, read: 0 }, false);
+      if (this.endpoint !== -1) {
+        await this.zbSend({ device: this.addr, endpoint: this.endpoint, cluster: 6, read: 0 }, false);
+      } else {
+        await this.zbSend({ device: this.addr, cluster: 6, read: 0 }, false);
+      }
     }
     throw new this.platform.api.hap.HapStatusError(HAPStatus.OPERATION_TIMED_OUT);
   }

--- a/src/zbBridgeSwitch.ts
+++ b/src/zbBridgeSwitch.ts
@@ -61,11 +61,7 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
         await this.externalPower(power ? 'ON' : 'OFF');
       } else {
         this.power = power;
-        if (this.endpoint !== -1) {
-          await this.zbSend({ device: this.addr, endpoint: this.endpoint, send: { Power: (this.power ? 'On' : 'Off') } });
-        } else {
-          await this.zbSend({ device: this.addr, send: { Power: (this.power ? 'On' : 'Off') } });
-        }
+        await this.zbSend({ device: this.addr, endpoint: this.endpoint, send: { Power: (this.power ? 'On' : 'Off') } });
       }
     }
   }
@@ -77,11 +73,7 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
     if (this.powerTopic !== undefined) {
       await this.externalPower();
     } else {
-      if (this.endpoint !== -1) {
-        await this.zbSend({ device: this.addr, endpoint: this.endpoint, cluster: 6, read: 0 }, false);
-      } else {
-        await this.zbSend({ device: this.addr, cluster: 6, read: 0 }, false);
-      }
+      await this.zbSend({ device: this.addr, endpoint: this.endpoint, cluster: 6, read: 0 }, false);
     }
     throw new this.platform.api.hap.HapStatusError(HAPStatus.OPERATION_TIMED_OUT);
   }

--- a/src/zbBridgeSwitch.ts
+++ b/src/zbBridgeSwitch.ts
@@ -39,7 +39,7 @@ export class ZbBridgeSwitch extends ZbBridgeAccessory {
   }
 
   onStatusUpdate(msg) {
-    if (msg.Power !== undefined) {
+    if (msg.Power !== undefined && ((this.endpoint !== -1 && msg.Endpoint === this.endpoint) || this.endpoint === -1)) {
       this.setPower(msg.Power === 1);
     }
     this.log('%s',


### PR DESCRIPTION
Hi, I added endpoint into addressing and identify switch entities, because it's important for some multiChannel devices. It's more less compatible with your version (if endpoint is not defined, it's same - with one different: I block rename of device during initiation. It's because with endpoint it makes troubles, you will address some device more then once and rename it and so on). 